### PR TITLE
Add new User Combination account page

### DIFF
--- a/packages/web/i18n/en/account.json
+++ b/packages/web/i18n/en/account.json
@@ -80,6 +80,7 @@
   "promotion_records": "Promotions",
   "reset_default": "Restore the default configuration",
   "team": "Team",
+  "user_combination": "User Combination",
   "third_party": "Third Party",
   "usage_records": "Usage"
 }

--- a/packages/web/i18n/zh-CN/account.json
+++ b/packages/web/i18n/zh-CN/account.json
@@ -81,6 +81,7 @@
   "promotion_records": "促销记录",
   "reset_default": "恢复默认配置",
   "team": "团队管理",
+  "user_combination": "用户组合",
   "third_party": "第三方账号",
   "usage_records": "使用记录"
 }

--- a/packages/web/i18n/zh-Hant/account.json
+++ b/packages/web/i18n/zh-Hant/account.json
@@ -80,6 +80,7 @@
   "promotion_records": "促銷記錄",
   "reset_default": "恢復預設設定",
   "team": "團隊管理",
+  "user_combination": "用戶組合",
   "third_party": "第三方賬號",
   "usage_records": "使用記錄"
 }

--- a/projects/app/src/pageComponents/account/AccountContainer.tsx
+++ b/projects/app/src/pageComponents/account/AccountContainer.tsx
@@ -22,6 +22,7 @@ export enum TabEnum {
   'apikey' = 'apikey',
   'loginout' = 'loginout',
   'team' = 'team',
+  'userCombination' = 'userCombination',
   'model' = 'model'
 }
 
@@ -48,6 +49,11 @@ const AccountContainer = ({
       icon: 'support/user/userLight',
       label: t('account:personal_information'),
       value: TabEnum.info
+    },
+    {
+      icon: 'support/user/usersLight',
+      label: t('account:user_combination'),
+      value: TabEnum.userCombination
     },
     ...(feConfigs?.isPlus
       ? [

--- a/projects/app/src/pages/account/userCombination/index.tsx
+++ b/projects/app/src/pages/account/userCombination/index.tsx
@@ -1,0 +1,204 @@
+'use client';
+import { serviceSideProps } from '@/web/common/i18n/utils';
+import AccountContainer from '@/pageComponents/account/AccountContainer';
+import { Box, Flex } from '@chakra-ui/react';
+import Icon from '@fastgpt/web/components/common/Icon';
+import { useTranslation } from 'next-i18next';
+import TeamSelector from '@/pageComponents/account/TeamSelector';
+import { useUserStore } from '@/web/support/user/useUserStore';
+import React, { useMemo } from 'react';
+import { useContextSelector } from 'use-context-selector';
+import { useRouter } from 'next/router';
+import FillRowTabs from '@fastgpt/web/components/common/Tabs/FillRowTabs';
+import MyIcon from '@fastgpt/web/components/common/Icon';
+import { TeamMemberRoleEnum } from '@fastgpt/global/support/user/team/constant';
+import { TeamContext, TeamModalContextProvider } from '@/pageComponents/account/team/context';
+import dynamic from 'next/dynamic';
+import { useSystemStore } from '@/web/common/system/useSystemStore';
+import { useToast } from '@fastgpt/web/hooks/useToast';
+
+const MemberTable = dynamic(() => import('@/pageComponents/account/team/MemberTable'));
+const PermissionManage = dynamic(
+  () => import('@/pageComponents/account/team/PermissionManage/index')
+);
+const OperationLogTable = dynamic(() => import('@/pageComponents/account/team/OperationLog/index'));
+const GroupManage = dynamic(() => import('@/pageComponents/account/team/GroupManage/index'));
+const OrgManage = dynamic(() => import('@/pageComponents/account/team/OrgManage/index'));
+const HandleInviteModal = dynamic(
+  () => import('@/pageComponents/account/team/Invite/HandleInviteModal')
+);
+
+export enum TeamTabEnum {
+  member = 'member',
+  org = 'org',
+  group = 'group',
+  permission = 'permission',
+  audit = 'audit'
+}
+
+const UserCombination = () => {
+  const router = useRouter();
+
+  const invitelinkid = useMemo(() => {
+    const _id = router.query.invitelinkid;
+    if (!_id && typeof _id !== 'string') {
+      return '';
+    } else {
+      return _id as string;
+    }
+  }, [router.query.invitelinkid]);
+
+  const { teamTab = TeamTabEnum.member } = router.query as { teamTab: `${TeamTabEnum}` };
+
+  const { t } = useTranslation();
+  const { userInfo, teamPlanStatus } = useUserStore();
+  const standardPlan = teamPlanStatus?.standard;
+  const level = standardPlan?.currentSubLevel;
+  const { subPlans } = useSystemStore();
+  const planContent = useMemo(() => {
+    const plan = level !== undefined ? subPlans?.standard?.[level] : undefined;
+
+    if (!plan) return;
+    return {
+      permissionTeamOperationLog: plan.permissionTeamOperationLog
+    };
+  }, [subPlans?.standard, level]);
+  const { toast } = useToast();
+
+  const { setEditTeamData, teamSize } = useContextSelector(TeamContext, (v) => v);
+
+  const Tabs = useMemo(
+    () => (
+      <FillRowTabs
+        list={[
+          { label: t('account_team:member'), value: TeamTabEnum.member },
+          { label: t('account_team:org'), value: TeamTabEnum.org },
+          { label: t('account_team:group'), value: TeamTabEnum.group },
+          { label: t('account_team:permission'), value: TeamTabEnum.permission },
+          { label: t('account_team:audit_log'), value: TeamTabEnum.audit }
+        ]}
+        px={'1rem'}
+        value={teamTab}
+        onChange={(e) => {
+          if (e === TeamTabEnum.audit && !planContent?.permissionTeamOperationLog) {
+            toast({
+              status: 'warning',
+              title: t('common:not_permission')
+            });
+            return;
+          }
+          router.replace({
+            query: {
+              ...router.query,
+              teamTab: e
+            }
+          });
+        }}
+      />
+    ),
+    [router, t, teamTab]
+  );
+
+  return (
+    <AccountContainer>
+      <Flex h={'100%'} flexDirection={'column'}>
+        {/* header */}
+        <Flex
+          w={'100%'}
+          h={'3.5rem'}
+          px={'1.56rem'}
+          py={'0.56rem'}
+          borderBottom={'1px solid'}
+          borderColor={'myGray.200'}
+          bg={'myGray.25'}
+          align={'center'}
+          gap={6}
+          justify={'space-between'}
+        >
+          <Flex align={'center'}>
+            <Flex gap={2} color={'myGray.900'}>
+              <Icon name="support/user/usersLight" w={'1.25rem'} h={'1.25rem'} />
+              <Box fontWeight={'500'} fontSize={'1rem'}>
+                {t('account:user_combination')}
+              </Box>
+            </Flex>
+            <Flex align={'center'} ml={6}>
+              <TeamSelector height={'28px'} />
+            </Flex>
+            {userInfo?.team?.role === TeamMemberRoleEnum.owner && (
+              <Flex align={'center'} justify={'center'} ml={2} p={'0.44rem'}>
+                <MyIcon
+                  name="edit"
+                  w="18px"
+                  cursor="pointer"
+                  _hover={{
+                    color: 'primary.500'
+                  }}
+                  onClick={() => {
+                    if (!userInfo?.team) return;
+                    setEditTeamData({
+                      id: userInfo.team.teamId,
+                      name: userInfo.team.teamName,
+                      avatar: userInfo.team.avatar,
+                      notificationAccount: userInfo.team.notificationAccount
+                    });
+                  }}
+                />
+              </Flex>
+            )}
+          </Flex>
+
+          <Box
+            float={'right'}
+            color={'myGray.900'}
+            h={'1.25rem'}
+            px={'0.5rem'}
+            py={'0.125rem'}
+            fontSize={'0.75rem'}
+            borderRadius={'1.25rem'}
+            bg={'myGray.150'}
+          >
+            {t('account_team:total_team_members', { amount: teamSize })}
+          </Box>
+        </Flex>
+
+        {/* table */}
+        <Box
+          py={'1.5rem'}
+          px={'2rem'}
+          flex={'1 0 0'}
+          display={'flex'}
+          flexDirection={'column'}
+          overflow={'auto'}
+        >
+          {teamTab === TeamTabEnum.member && <MemberTable Tabs={Tabs} />}
+          {teamTab === TeamTabEnum.org && <OrgManage Tabs={Tabs} />}
+          {teamTab === TeamTabEnum.group && <GroupManage Tabs={Tabs} />}
+          {teamTab === TeamTabEnum.permission && <PermissionManage Tabs={Tabs} />}
+          {teamTab === TeamTabEnum.audit && <OperationLogTable Tabs={Tabs} />}
+        </Box>
+      </Flex>
+      {invitelinkid && <HandleInviteModal invitelinkid={invitelinkid} />}
+    </AccountContainer>
+  );
+};
+
+export async function getServerSideProps(content: any) {
+  return {
+    props: {
+      ...(await serviceSideProps(content, ['account', 'account_team', 'user']))
+    }
+  };
+}
+
+const Render = () => {
+  const { userInfo } = useUserStore();
+
+  return !!userInfo?.team ? (
+    <TeamModalContextProvider>
+      <UserCombination />
+    </TeamModalContextProvider>
+  ) : null;
+};
+
+export default React.memo(Render);


### PR DESCRIPTION
## Summary
- add a new `userCombination` tab always visible in account settings
- implement `/account/userCombination` page based on team management
- localize new `user_combination` tab label in EN, zh-CN and zh-Hant

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6846e869b73c8332aef3af69d566e8eb